### PR TITLE
Server immich

### DIFF
--- a/generic/server/all.nix
+++ b/generic/server/all.nix
@@ -11,6 +11,7 @@ _:
     # > Checking runtime dependencies for calibreweb-0.6.25-py3-none-any.whl
     # >   - requests<2.33.0,>=2.32.0 not satisfied by version 2.33.1
     # ./calibre.nix
+    ./immich.nix
     ./traefik.nix
   ];
 }

--- a/generic/server/immich.nix
+++ b/generic/server/immich.nix
@@ -4,5 +4,9 @@ _:
   services.immich = {
     enable = true;
     group = "media";
+    mediaLocation = "/mnt/immich";
+    environment = {
+      IMMICH_TELEMETRY_INCLUDE = "all";
+    };
   };
 }

--- a/generic/server/immich.nix
+++ b/generic/server/immich.nix
@@ -1,0 +1,8 @@
+_:
+
+{
+  services.immich = {
+    enable = true;
+    group = "media";
+  };
+}

--- a/generic/server/immich.nix
+++ b/generic/server/immich.nix
@@ -8,5 +8,29 @@ _:
     environment = {
       IMMICH_TELEMETRY_INCLUDE = "all";
     };
+    settings = {
+      backup.database = {
+          enabled = true;
+          cronExpression = "0 02 * * *";
+          keepLastAmount = 20;
+        };
+      metadata.faces.import = true;
+      newVersionCheck.enabled = false;
+      nightlyTasks = {
+        clusterNewFaces = true;
+        databaseCleanup = true;
+        generateMemories = true;
+        missingThumbnails = true;
+        syncQuotaUsage = true;
+        startTime = "00:00";
+      };
+      passwordLogin.enabled = true;
+      reverseGeocoding.enabled = true;
+      storageTemplate = {
+        enabled = true;
+        hashVerificationEnabled = true;
+        template = "{{y}}/{{MM}}/{{dd}}/{{HH}}{{mm}}{{SSS}}_{{filename}}";
+      };
+    };
   };
 }

--- a/generic/server/immich.nix
+++ b/generic/server/immich.nix
@@ -10,10 +10,10 @@ _:
     };
     settings = {
       backup.database = {
-          enabled = true;
-          cronExpression = "0 02 * * *";
-          keepLastAmount = 20;
-        };
+        enabled = true;
+        cronExpression = "0 02 * * *";
+        keepLastAmount = 20;
+      };
       metadata.faces.import = true;
       newVersionCheck.enabled = false;
       nightlyTasks = {

--- a/generic/server/smb.nix
+++ b/generic/server/smb.nix
@@ -37,7 +37,7 @@
         "dir_mode=0770"
       ];
     };
-    "/mnt/immich" = {
+    "/mnt/immich" = lib.mkIf config.services.immich.enable {
       device = "//pumpkin.lc.brotherwolf.ca/Immich";
       fsType = "cifs";
       options = [

--- a/generic/server/smb.nix
+++ b/generic/server/smb.nix
@@ -1,15 +1,15 @@
-{ config, ... }:
+{ config, lib, ... }:
 
 {
   boot.supportedFilesystems = [ "cifs" ];
   users.groups.media = { };
   users.users.media = {
     isSystemUser = true;
-    group = "media";
+    group = "media"; 
   };
 
   fileSystems = {
-    "/mnt/media" = {
+    "/mnt/media" = lib.mkIf config.services.jellyfin.enable {
       device = "//pumpkin.lc.brotherwolf.ca/Media";
       fsType = "cifs";
       options = [
@@ -23,7 +23,7 @@
         "dir_mode=0770"
       ];
     };
-    "/mnt/references" = {
+    "/mnt/references" = lib.mkIf config.services.calibre-web.enable {
       device = "//pumpkin.lc.brotherwolf.ca/Calibre";
       fsType = "cifs";
       options = [

--- a/generic/server/smb.nix
+++ b/generic/server/smb.nix
@@ -37,5 +37,19 @@
         "dir_mode=0770"
       ];
     };
+    "/mnt/immich" = {
+      device = "//pumpkin.lc.brotherwolf.ca/Immich";
+      fsType = "cifs";
+      options = [
+        "credentials=${config.age.secrets.pumpkin-smb-credentials.path}"
+        "x-systemd.automount"
+        "noauto"
+        "nofail"
+        "uid=media"
+        "gid=media"
+        "file_mode=0660"
+        "dir_mode=0770"
+      ];
+    };
   };
 }

--- a/generic/server/smb.nix
+++ b/generic/server/smb.nix
@@ -5,7 +5,7 @@
   users.groups.media = { };
   users.users.media = {
     isSystemUser = true;
-    group = "media"; 
+    group = "media";
   };
 
   fileSystems = {

--- a/generic/server/smb.nix
+++ b/generic/server/smb.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, ... }:
 
 {
   boot.supportedFilesystems = [ "cifs" ];
@@ -9,7 +9,7 @@
   };
 
   fileSystems = {
-    "/mnt/media" = lib.mkIf config.services.jellyfin.enable {
+    "/mnt/media" = {
       device = "//pumpkin.lc.brotherwolf.ca/Media";
       fsType = "cifs";
       options = [
@@ -23,7 +23,7 @@
         "dir_mode=0770"
       ];
     };
-    "/mnt/references" = lib.mkIf config.services.calibre-web.enable {
+    "/mnt/references" = {
       device = "//pumpkin.lc.brotherwolf.ca/Calibre";
       fsType = "cifs";
       options = [
@@ -37,7 +37,7 @@
         "dir_mode=0770"
       ];
     };
-    "/mnt/immich" = lib.mkIf config.services.immich.enable {
+    "/mnt/immich" = {
       device = "//pumpkin.lc.brotherwolf.ca/Immich";
       fsType = "cifs";
       options = [

--- a/generic/server/traefik.nix
+++ b/generic/server/traefik.nix
@@ -103,6 +103,10 @@
           rule = "Host(`navidrome.brotherwolf.ca`) || Host(`navidrome.lc.brotherwolf.ca`)";
           service = "navidrome";
         };
+        immich = lib.mkIf config.services.immich.enable {
+          rule = "Host(`immich.brotherwolf.ca`) || Host(`immich.lc.brotherwolf.ca`)";
+          service = "immich";
+        };
       };
       services = {
         calibre.loadBalancer = lib.mkIf config.services.calibre-web.enable {
@@ -199,6 +203,11 @@
         navidrome.loadBalancer = lib.mkIf config.services.navidrome.enable {
           servers = [
             { url = "http://localhost:4533"; }
+          ];
+        };
+        immich.loadBalancer = lib.mkIf config.services.immich.enable {
+          servers = [
+            { url = "http://localhost:2283"; }
           ];
         };
       };

--- a/generic/server/visibility.nix
+++ b/generic/server/visibility.nix
@@ -257,8 +257,8 @@
           static_configs = [
             {
               targets = [
-                "pumpkin.lc.brotherwolf.ca:30363"
-                "pumpkin.lc.brotherwolf.ca:30364"
+                "localhost:8081"
+                "localhost:8082"
               ];
             }
           ];


### PR DESCRIPTION
This pull request adds support for the Immich photo management service to the NixOS server configuration. It introduces a new module for Immich, ensures proper mounting of its media storage via SMB, and integrates Immich with the Traefik reverse proxy for web access. Additionally, SMB mount points are now conditionally enabled based on whether their respective services are active.

**Immich service integration:**

* Added a new `immich.nix` module that configures the Immich service, including settings for media storage, backup, metadata import, and scheduled tasks. (`generic/server/immich.nix`, [[1]](diffhunk://#diff-928fecb4178f3a3e016a13eec3faac971fd9c94b4f9700dea3a492895a7cc3d1R1-R36) [[2]](diffhunk://#diff-719cb8d034fdbd12d51f0cc1aee5d2328f9b69cf74e5b5be69eb2ba6a9a2540aR14)

**SMB mount improvements:**

* Updated `smb.nix` to mount `/mnt/immich` only if Immich is enabled, with appropriate credentials and permissions. Other SMB mounts (`/mnt/media`, `/mnt/references`) are now also conditionally mounted based on their respective services. (`generic/server/smb.nix`, [[1]](diffhunk://#diff-313ff49bec306ab4b5c380e1e13051491e11ff51dd4305d9729af27bf36cd52aL1-R1) [[2]](diffhunk://#diff-313ff49bec306ab4b5c380e1e13051491e11ff51dd4305d9729af27bf36cd52aL12-R12) [[3]](diffhunk://#diff-313ff49bec306ab4b5c380e1e13051491e11ff51dd4305d9729af27bf36cd52aL26-R26) [[4]](diffhunk://#diff-313ff49bec306ab4b5c380e1e13051491e11ff51dd4305d9729af27bf36cd52aR40-R53)

**Traefik reverse proxy configuration:**

* Added Traefik rules and load balancer configuration for Immich, making it accessible via `immich.brotherwolf.ca` and `immich.lc.brotherwolf.ca` when the service is enabled. (`generic/server/traefik.nix`, [[1]](diffhunk://#diff-1dbbc67ccc48e5411c96e41f1f1f91232332f04533f86916cc699772a87ab47fR106-R109) [[2]](diffhunk://#diff-1dbbc67ccc48e5411c96e41f1f1f91232332f04533f86916cc699772a87ab47fR208-R212)